### PR TITLE
Register Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2166,9 +2166,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/src/app/login/hooks/useLogin.ts
+++ b/src/app/login/hooks/useLogin.ts
@@ -50,10 +50,10 @@ export function useLogin() {
 
 		try {
 			// Call the AuthService login API
-			const { access_token } = await AuthService.login(email, password);
+			const { token } = await AuthService.login(email, password);
 
 			// Store the access token in AuthContext
-			setAccessToken(access_token);
+			setAccessToken(token);
 
 			// Return success
 			return true;

--- a/src/app/shared/services/AuthService.ts
+++ b/src/app/shared/services/AuthService.ts
@@ -10,8 +10,16 @@ import axios from "axios";
 
 // Type definitions for API responses
 export type LoginResponse = {
-  access_token: string;
-  refresh_token: string;
+  success: boolean;
+  token: string;
+  expires_in: number;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+    is_verified: boolean;
+  };
 };
 
 export type RegisterResponse = {
@@ -45,7 +53,7 @@ export type RegisterRequest = {
   role?: string;
 };
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://gearfalcon.test";
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 // Create an Axios instance for all auth-related requests
 const authHttp = axios.create({
@@ -62,9 +70,15 @@ authHttp.interceptors.response.use(
   (error) => {
     // Log error for debugging
     console.error('Auth API Error:', {
+      message: error.message,
       status: error.response?.status,
+      statusText: error.response?.statusText,
       data: error.response?.data,
       url: error.config?.url,
+      baseURL: error.config?.baseURL,
+      method: error.config?.method,
+      timeout: error.code === 'ECONNABORTED' ? 'Request timeout' : null,
+      network: error.code === 'ERR_NETWORK' ? 'Network error - check if backend is running' : null,
     });
     
     return Promise.reject(error);
@@ -75,18 +89,13 @@ authHttp.interceptors.response.use(
 export const AuthService = {
   // Login function
   async login(email: string, password: string): Promise<LoginResponse> {
-    const { data } = await authHttp.post<LoginResponse>("/api/auth/login", { 
+    const { data } = await authHttp.post<LoginResponse>("/auth/login", { 
       email, 
       password 
     });
     return data;
   },
 
-  // Token refresh function
-  async refresh(): Promise<{ access_token: string }> {
-    const { data } = await authHttp.post<{ access_token: string }>("/api/auth/refresh", {});
-    return data;
-  },
 
   // Registration function
   async register(userData: RegisterRequest): Promise<RegisterResponse> {

--- a/src/app/shared/services/axiosClient.ts
+++ b/src/app/shared/services/axiosClient.ts
@@ -29,10 +29,10 @@ Usage summary:
 // src/app/shared/services/axiosClient.ts
 import axios, { AxiosError, AxiosInstance } from "axios";
 import type { InternalAxiosRequestConfig } from "axios";
-import { AuthService } from "@/app/shared/services/AuthService";
+// import { AuthService } from "@/app/shared/services/AuthService"; // Removed - no refresh endpoint
 
 // Base API URL from environment variable
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 // ----------------------
 // Token bridge mechanism
@@ -58,34 +58,11 @@ export const http: AxiosInstance = axios.create({
   withCredentials: true, // include cookies for refresh token
 });
 
-// Separate instance for token refresh to avoid recursion through interceptors
-const refreshHttp = axios.create({
-  baseURL: BASE_URL,
-  withCredentials: true,
-});
+// Removed refreshHttp instance - no refresh endpoint in backend
 
 // ----------------------
-// Token refresh queue
+// Token refresh queue - REMOVED (no refresh endpoint in backend)
 // ----------------------
-let isRefreshing = false; // Flag to prevent multiple simultaneous refresh calls
-let pendingQueue: Array<{
-  resolve: (token: string) => void;
-  reject: (err: unknown) => void;
-}> = [];
-
-// Process queued requests after token refresh completes
-function processQueue(error: unknown, token: string | null) {
-  pendingQueue.forEach(({ resolve, reject }) => {
-    if (error) {
-      reject(error); // Reject all queued requests if refresh failed
-    } else if (token) {
-      resolve(token); // Resolve with new token
-    } else {
-      reject(new Error("No token available"));
-    }
-  });
-  pendingQueue = []; // Clear queue
-}
 
 // ----------------------
 // Request interceptor
@@ -105,62 +82,18 @@ http.interceptors.request.use((config: InternalAxiosRequestConfig) => {
 });
 
 // ----------------------
-// Response interceptor
+// Response interceptor - SIMPLIFIED (no refresh functionality)
 // ----------------------
 http.interceptors.response.use(
   (response) => response, // Pass successful responses
   async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
-
-    // Only handle 401 errors, skip if already retried
-    if (error.response?.status !== 401 || originalRequest._retry) {
-      return Promise.reject(error);
-    }
-
-    originalRequest._retry = true; // mark to avoid infinite retry loops
-
-    if (isRefreshing) {
-      // If a refresh is already in progress, queue this request
-      return new Promise((resolve, reject) => {
-        pendingQueue.push({
-          resolve: (newToken: string) => {
-            const headers: any = originalRequest.headers as any;
-            if (typeof headers.set === "function") {
-              headers.set("Authorization", `Bearer ${newToken}`);
-            } else {
-              headers["Authorization"] = `Bearer ${newToken}`;
-            }
-            resolve(http(originalRequest)); // Retry original request
-          },
-          reject,
-        });
-      });
-    }
-
-    isRefreshing = true;
-
-    try {
-      // Call backend refresh endpoint; refresh token is sent via HTTP-only cookie
-      const { access_token } = await AuthService.refresh();
-
-      setAccessToken(access_token); // Update in-memory token
-      processQueue(null, access_token); // Retry all queued requests
-
-      // Retry original request with new token
-      const headers: any = originalRequest.headers as any;
-      if (typeof headers.set === "function") {
-        headers.set("Authorization", `Bearer ${access_token}`);
-      } else {
-        headers["Authorization"] = `Bearer ${access_token}`;
-      }
-      return http(originalRequest);
-    } catch (refreshErr) {
-      processQueue(refreshErr, null); // Reject queued requests
+    // Handle 401 errors by clearing token and redirecting to login
+    if (error.response?.status === 401) {
       setAccessToken(null); // Clear token in memory, effectively logging out
-      return Promise.reject(refreshErr);
-    } finally {
-      isRefreshing = false;
+      // You might want to redirect to login page here
+      // window.location.href = '/login';
     }
+    return Promise.reject(error);
   }
 );
 


### PR DESCRIPTION
# Align auth API, fix frontend-backend connectivity, and auto-cleanup unverified users after 5 minutes
## Summary
Standardized frontend auth endpoints and response types to match backend.
Fixed frontend API base URL in Docker so browser clients reach the backend.
Removed unused refresh flow and simplified error handling.
Enforced 5-minute email verification window and added automatic cleanup of expired, unverified users.

### Changes
### Frontend
src/app/shared/services/AuthService.ts
Aligned endpoints: /auth/login, /auth/register, /auth/verify-email, /auth/resend-verification.
Updated LoginResponse to backend shape: { success, token, expires_in, user }.
Removed unused token refresh API usage.
Enhanced Axios error logging with message, statusText, baseURL, method, and network/timeout hints.
src/app/shared/services/axiosClient.ts
Removed refresh-token flow (no backend endpoint).
Simplified 401 handling: clear in-memory token; no automatic retry.
Removed refresh-related queue and secondary Axios instance.
src/app/login/hooks/useLogin.ts
Updated to use token (instead of access_token) from login response.

### Docker/Config
gearfalcon-api/docker-compose.yml
Set NEXT_PUBLIC_API_URL=http://localhost:8080/ for the frontend service to work when accessed from a browser on the host.

### Backend
src/Application/Services/UserRegistrationService.php
Set verification_code_expires_at to +5 minutes.
src/Application/Services/EmailVerificationService.php
Set verification code expiry to +5 minutes for send and resend paths.
src/Infrastructure/Repositories/UserRepository.php
Added deleteExpiredUnverifiedUsers(int $intervalMinutes = 5): int to delete unverified users with expired verification window.
src/Infrastructure/Container.php
Invokes deleteExpiredUnverifiedUsers(5) on bootstrap; logs results, non-blocking on failure.

## Rationale
Frontend was using mixed /api/auth/* and /auth/* endpoints; backend exposes /auth/*.
Frontend expected { access_token } but backend returns { token }.
Browser could not resolve [http://backend:80](http://backend/); moved to http://localhost:8080/ for host access.
No refresh endpoint exists; removed dead code and simplified error handling.
Product requirement: auto-delete unverified accounts after 5 minutes to keep DB clean.

### How to Test
### Connectivity
Start stack: docker-compose up -d.
Verify health: http://localhost:8080/health returns 200 JSON.
Frontend loads at http://localhost:3000/.

## Auth flows
Register at http://localhost:3000/register.
Observe request to POST http://localhost:8080/auth/register.
Try login at http://localhost:3000/login; token should be stored in memory; requests include Authorization: Bearer .
Verification expiry and cleanup
Register a user and do not verify.
Wait >5 minutes.
Trigger any backend request (e.g., load /health) to execute cleanup.
Confirm user is deleted:
Inside DB container:
docker exec -it gearfalcon-api-db-1 mysql -u root -p -e "USE gearfalcon_db_dev; SELECT * FROM users WHERE email='[you@example.com](mailto:you@example.com)';"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Login now uses the updated authentication response with token and user details.
  - Added support for email verification and resending verification.
- Refactor
  - Removed automatic token refresh; sessions expire and require re-login.
  - 401 responses now sign you out instead of retrying.
- Chores
  - Updated default backend base URL for local environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->